### PR TITLE
Fixed user account details form opt-in checkboxes already set were displayed.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -509,17 +509,22 @@ class WooCommerce {
         'label' => 'Newsletter Freizeit',
         'priority' => 120,
       ],
-      'confirm_agb' => [
-        'label' => 'AGB-Bestätigung',
-        'priority' => 130,
-      ],
     ];
     $userinfo = Plugin::buildUserInfo('account', get_current_user_ID());
 
+    // Sets general terms & conditions opt-in as a hidden field if already confirmed.
+    if (isset($userinfo['optins']['confirm_agb'])) {
+      echo '<p class="form-row hidden" id="confirm_agb_field">
+              <input type="hidden" class="input-hidden" name="confirm_agb" id="confirm_agb" value="' . $userinfo['optins']['confirm_agb'] . '" />
+            </p>';
+    }
+    else {
+      $opt_ins['confirm_agb'] = [
+        'label' => 'AGB-Bestätigung',
+        'priority' => 130,
+      ];
+    }
     foreach ($opt_ins as $opt_in_id => $opt_in_args) {
-      if ($userinfo['optins'][$opt_in_id]) {
-        continue;
-      }
       $args = [
         'type' => 'checkbox',
         'label' => $opt_in_args['label'],

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -514,8 +514,12 @@ class WooCommerce {
         'priority' => 130,
       ],
     ];
+    $userinfo = Plugin::buildUserInfo('account', get_current_user_ID());
 
     foreach ($opt_ins as $opt_in_id => $opt_in_args) {
+      if ($userinfo['optins'][$opt_in_id]) {
+        continue;
+      }
       $args = [
         'type' => 'checkbox',
         'label' => $opt_in_args['label'],


### PR DESCRIPTION
Related to task:

- [Do not display opt-in for general terms & conditions (confirm_agb) once confirmed, but ensure to retain value in updates](https://app.asana.com/0/383242129844224/734773366153843)