### PR TITLE
Fixed duplicate user/customer data in SSO/alfa after associating existing subscription or upgrading trial subscription from dummy address.

### DIFF
--- a/src/Alfa.php
+++ b/src/Alfa.php
@@ -77,7 +77,8 @@ class Alfa {
 
   public static function getPurchases(array $alfa_purchases = NULL, $raw = FALSE) {
     if (!isset($alfa_purchases)) {
-      $alfa_purchases = get_user_meta(get_current_user_ID(), 'alfa_purchases', TRUE);
+      $userinfo = get_user_meta(get_current_user_ID(), Plugin::USER_META_USERINFO, TRUE);
+      $alfa_purchases = $userinfo['alfa_purchases'] ?: [];
     }
     if (empty($alfa_purchases)) {
       $alfa_purchases = ['purchases' => []];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -487,7 +487,6 @@ class Plugin {
 
     $subscriber_id = $user_claims['subscriber_id'] ?? $user_claims['subscribernr'];
     update_user_meta($user_id, 'billing_subscriber_id', $subscriber_id);
-    update_user_meta($user_id, 'alfa_purchases', $user_claims['alfa_purchases']);
     update_user_meta($user_id, 'alfa_dummy_address', $user_claims['alfa_dummy_address']);
 
     // A user_status 'confirmed' (active/blocked) is not supported by WordPress

--- a/src/Server.php
+++ b/src/Server.php
@@ -9,11 +9,11 @@ namespace Netzstrategen\Ssofact;
 
 class Server {
 
-  const ENDPOINT_IS_EMAIL_REGISTERED = '/REST/services/authenticate/user/IsEmailRegistered';
+  const ENDPOINT_EMAIL_VALIDATE_NEW = '/REST/services/authenticate/user/IsEmailRegistered';
 
   const ENDPOINT_LOGIN_VALIDATE = '/REST/services/authenticate/user/checkUserCredentials';
 
-  const ENDPOINT_SUBSCRIBER_ID = '/REST/services/authenticate/user/checkAboNo';
+  const ENDPOINT_SUBSCRIBER_VALIDATE = '/REST/services/authenticate/user/checkAboNo';
 
   const ENDPOINT_USER_UPDATE = '/REST/services/authenticate/user/updateUser';
 
@@ -32,7 +32,7 @@ class Server {
    * @return null|array
    */
   public static function isEmailRegistered($email) {
-    $response = Server::request('POST', static::ENDPOINT_IS_EMAIL_REGISTERED, ['email' => $email]);
+    $response = Server::request('POST', static::ENDPOINT_EMAIL_VALIDATE_NEW, ['email' => $email]);
     return $response;
   }
 
@@ -57,10 +57,11 @@ class Server {
   /**
    * Returns whether the subscriber ID matches the name and zipcode.
    *
-   * @return null!array
+   * @return null|array
    */
-  public static function checkSubscriberId($subscriber_id, $first_name, $last_name, $zip_code) {
-    $response = Server::request('POST', static::ENDPOINT_SUBSCRIBER_ID, [
+  public static function checkAboNo($email, $subscriber_id, $first_name, $last_name, $zip_code) {
+    $response = Server::request('POST', static::ENDPOINT_SUBSCRIBER_VALIDATE, [
+      'email' => $email,
       'abono' => $subscriber_id,
       'firstname' => $first_name,
       'lastname' => $last_name,

--- a/src/Server.php
+++ b/src/Server.php
@@ -15,6 +15,8 @@ class Server {
 
   const ENDPOINT_SUBSCRIBER_VALIDATE = '/REST/services/authenticate/user/checkAboNo';
 
+  const ENDPOINT_USER_VALIDATE = '/REST/services/authenticate/user/validateUser';
+
   const ENDPOINT_USER_UPDATE = '/REST/services/authenticate/user/updateUser';
 
   const ENDPOINT_USER_CREATE_WITH_PURCHASE = '/REST/services/authorize/purchase/registerUserAndPurchase';
@@ -67,6 +69,22 @@ class Server {
       'lastname' => $last_name,
       'zipcode' => $zip_code,
     ]);
+    return $response;
+  }
+
+  /**
+   * Returns whether a given address has a subscriber ID already.
+   *
+   * @param array $address
+   *   The customer address fields to validate.
+   *   - 'firstname' may be omitted for companies (salutation 'Firma').
+   *
+   * @return null|array
+   *
+   * @see Plugin::buildUserInfo()
+   */
+  public static function validateUser(array $address) {
+    $response = Server::request('POST', static::ENDPOINT_USER_VALIDATE, $address);
     return $response;
   }
 

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -1161,6 +1161,27 @@ var nfyFacebookAppId = '637920073225349';
       if (!empty($response['aboNo'])) {
         update_user_meta($order->get_customer_id(), 'billing_subscriber_id', $response['aboNo']);
       }
+
+      // Save a fake purchase into user's metadata to prevent the trial
+      // subscription form from appearing on the user account edit form.
+      // @see Plugin::isArticleTestConfirmationPage()
+      // @todo Remove this when SSO server change events are implemented.
+      if ($sku === 'stite') {
+        $userinfo = get_user_meta($order->get_customer_id(), Plugin::USER_META_USERINFO, TRUE) ?: [];
+        $userinfo['alfa_purchases']['purchases'][] = [
+          'purchase' => [
+            'fake' => TRUE,
+            'type' => 'Product',
+            'object' => 'OABO',
+            'edition' => 'STDE',
+            'ivw' => 'i_121122',
+            'fromDay' => date_i18n('Ymd'),
+            'toDay' => date_i18n('Ymd', strtotime('+ 30 days')),
+          ],
+        ];
+        update_user_meta($order->get_customer_id(), Plugin::USER_META_USERINFO, $userinfo);
+      }
+
       // Remove subscriber validation response data from session, so that the
       // information in the user profile is based on the actual user profile data.
       $session = WC()->session;


### PR DESCRIPTION
The client now needs to pass the email address to the checkAboNo API to allow the SSO to additionally check whether the subscriber ID is associated with a different account already.

And if the checkAboNo validation was correct, the client needs to pass the validated subscriber ID to registerUserAndPurchase and registerPurchase APIs, so that the SSO does not invoke registerUser towards alfa, but essentially does the opposite and imports the data from that subscriber ID from alfa into the SSO user account.

The same procedure also applies to the updateUser API when a user attempts to associate their existing subscription to their user account.

Lastly, a user should still be able to associate their existing subscription as long as there is only a "dummy address" in alfa, which refers to a partial address for trial subscriptions whose otherwise required fields have been filled up with placeholder values.  ssoFACT announces these addresses as "alfa_dummy_address" in the UserInfo now.

In short:  If it's not a alfa_dummy_address, the user is always able to associate.

- https://jira.newsfactory.de/browse/HS-115
- https://jira.newsfactory.de/browse/HS-126
- https://app.asana.com/0/29283351247093/772388816921913
- https://app.asana.com/0/29283351247093/784199051178313
- https://app.asana.com/0/29283351247093/784199051178314